### PR TITLE
Renamed all occurences of "Derniers événements" to "Evenements des agendas" in widget french translation files

### DIFF
--- a/app/Resources/translations/widget.fr.yml
+++ b/app/Resources/translations/widget.fr.yml
@@ -1,4 +1,4 @@
-agenda: 'Derniers événements'
+agenda: 'Evénements des agendas'
 core_resource_logger: 'Traces des actions'
 my_workspaces: 'Mes formations'
 simple_text: Texte


### PR DESCRIPTION
fixes #80
